### PR TITLE
Support For Angled Labels

### DIFF
--- a/src/Adapter/Text.php
+++ b/src/Adapter/Text.php
@@ -10,14 +10,17 @@ use SVG\Nodes\Texts\SVGText;
 class Text extends SVGNodeContainer
 {
 
-	static function label(string $value, float $coordX, float $coordY): SVGText
+	static function label(string $value, float $coordX, float $coordY, int $angle = 0): SVGText
 	{
 		$value = trim($value);
 
 		$text = new SVGText($value, $coordX, $coordY);
 		$text->setAttribute('font-family', 'Sans-serif');
-		$text->setStyle('text-anchor', 'middle');
+		$text->setAttribute('text-anchor', $angle > 0 ? 'end':'middle');
 		$text->setStyle('font-size', 12);
+		$text->setStyle('transform-box', 'fill-box');
+		$text->setStyle('transform-origin', '100% 50%');
+		$text->setStyle('transform', 'rotate(-' . $angle . 'deg)');
 
 		return $text;
 	}

--- a/src/Charts/AbstractChart.php
+++ b/src/Charts/AbstractChart.php
@@ -334,9 +334,7 @@ abstract class AbstractChart
 			),
 		);
 
-		$angleInRadians = ((2*M_PI) / 360) * $this->labelAngle;
-
-		$this->paddingLabelX = (int)(sin($angleInRadians) * $maxLabelLength * 10);
+		$this->paddingLabelX = (int)(sin(deg2rad($this->labelAngle)) * $maxLabelLength * 8);
 	}
 
 	private function drawYaxis(): void

--- a/src/Charts/BarChart.php
+++ b/src/Charts/BarChart.php
@@ -145,6 +145,10 @@ class BarChart extends AbstractChart
 				$pointY = $dot->y + ($this->height - $this->computeDotY2($dot->value)) / 2 - 4;
 			}
 
+			if ($this->stacked) {
+				$pointY -= $this->paddingLabelX / 2;
+			}
+
 			$obj = Text::label((string) $dot->value, $pointX, $pointY);
 			$color = $this->getColor($indexSerie);
 

--- a/src/Charts/BubbleChart.php
+++ b/src/Charts/BubbleChart.php
@@ -89,6 +89,8 @@ class BubbleChart extends AbstractChart
 			$this->minY1 = min($this->minY1, $serie[1] + 10);
 			$this->maxY1 = max($this->maxY1, $serie[1] + 10);
 		}
+
+		$this->adjustPaddingXLabel();
 	}
 
 	protected function computeMinMaxXaxis(): void


### PR DESCRIPTION
This PR adds an new option to set the angle of series labels, this is a problem if you have many points or long labels. For example:

```php
(new \Pierresh\Simca\Charts\BarChart(800, 400))
    ->setSeries([
        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
    ])
    ->setLabels([
        '2024-06-01 01:00',
        '2024-06-01 02:00',
        '2024-06-01 03:00',
        '2024-06-01 04:00',
        '2024-06-01 05:00',
        '2024-06-01 06:00',
        '2024-06-01 07:00',
        '2024-06-01 08:00',
        '2024-06-01 09:00',
        '2024-06-01 10:00',
        '2024-06-01 11:00',
        '2024-06-01 12:00',
        '2024-06-01 13:00',
        '2024-06-01 14:00',
        '2024-06-01 15:00',
        '2024-06-01 16:00',
    ])
    ->render();
```

Gives:

![Image](https://github.com/user-attachments/assets/81218d70-9c42-4c20-a568-e6daac16074e)

Now:

```php
(new \Pierresh\Simca\Charts\BarChart(800, 400))
    ->setSeries([
        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
    ])
    ->setOptions([
        'labelAngle' => 60,
    ])
    ->setLabels([
        '2024-06-01 01:00',
        '2024-06-01 02:00',
        '2024-06-01 03:00',
        '2024-06-01 04:00',
        '2024-06-01 05:00',
        '2024-06-01 06:00',
        '2024-06-01 07:00',
        '2024-06-01 08:00',
        '2024-06-01 09:00',
        '2024-06-01 10:00',
        '2024-06-01 11:00',
        '2024-06-01 12:00',
        '2024-06-01 13:00',
        '2024-06-01 14:00',
        '2024-06-01 15:00',
        '2024-06-01 16:00',
    ])
    ->render();
```

![Screenshot from 2025-01-19 15-32-56](https://github.com/user-attachments/assets/7aa46af9-2069-4bb6-8b0b-9f9f61b5ce47)
