### PR TITLE
Option to make charts responsive

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Same as Line chart, just set the option `fillOpacity` to a value greater than 0 
 ### Radar Chart
 - Can be stacked
 
+#### Other options
+- `numLines` number of horizontal grid lines in the chart
+- `responsive` set to `false` to disable responsive mode
+- `showYAxis` set to `false` will hide the Y axis
+- `unitY1` / `unitY2` units for the Y axes
+
 ## Installation
 ```php
 composer require pierresh\simca
@@ -124,6 +130,15 @@ $chart = (new RadarChart(600, 400))
 Alternatively, you can replace `render()` with `renderBase64()` to get a base64 encoded SVG image.
 
 ## Development
+
+Clone the repository and install the dependencies:
+```bash
+git clone https://github.com/pierresh/simca
+
+cd simca
+
+composer install
+```
 
 There is a watcher script to automatically refresh the page when a change is made.
 

--- a/app/example.php
+++ b/app/example.php
@@ -7,6 +7,7 @@ use Pierresh\Simca\Charts\PieChart;
 use Pierresh\Simca\Charts\RadarChart;
 
 $chart = (new BarChart(600, 400))
+	->setOptions(['responsive' => false])
 	->setSeries([[10, 45, 30, 25], [15, 20, 15, 25], [5, 2, 10, 15]])
 	->setLabels(['A', 'B', 'C', 'D'])
 	->setColors(['#2dd55b', '#ffc409', '#0054e9'])
@@ -19,6 +20,7 @@ $chart = (new BarChart(600, 400))
 echo $chart;
 
 $chart = (new LineChart(600, 400))
+	->setOptions(['responsive' => false])
 	->setSeries([[10, 45, 30, 25], [15, 20, 15, 25]])
 	->setLabels([
 		'2024-06-01 08:00',
@@ -41,12 +43,14 @@ $chart = (new LineChart(600, 400))
 echo $chart;
 
 $chart = (new PieChart(600, 400))
+	->setOptions(['responsive' => false])
 	->setSeries([[14, 0.5], [3, 0.9], [5, 0.8], [5, 1], [5, 0.9]])
 	->render();
 
 echo $chart;
 
 $chart = (new BubbleChart(600, 400))
+	->setOptions(['responsive' => false])
 	->setSeries([
 		['2024-06-01 08:00', 40, 30],
 		['2024-06-01 09:00', 20, 15],
@@ -60,6 +64,7 @@ $chart = (new BubbleChart(600, 400))
 echo $chart;
 
 $chart = (new LineChart(600, 400))
+	->setOptions(['responsive' => false])
 	->setSeries([[10, 45, 30, 25], [15, 20, 15, 25]])
 	->setLabels([
 		'2024-06-01 08:00',
@@ -79,6 +84,7 @@ $chart = (new LineChart(600, 400))
 echo $chart;
 
 $chart = (new RadarChart(600, 400))
+	->setOptions(['responsive' => false])
 	->setSeries([
 		[65, 59, 90, 81, 56, 55, 40],
 		[38, 48, 40, 19, 96, 27, 100]

--- a/src/Adapter/SVG.php
+++ b/src/Adapter/SVG.php
@@ -10,6 +10,11 @@ class SVG
 {
 	static function build(int $width, int $height): PhpSvg
 	{
+		return new PhpSvg($width, $height);
+	}
+
+	static function buildResponsive(int $width, int $height): PhpSvg
+	{
 		$svg = new PhpSvg();
 
 		$svg->getDocument()

--- a/src/Adapter/SVG.php
+++ b/src/Adapter/SVG.php
@@ -10,6 +10,12 @@ class SVG
 {
 	static function build(int $width, int $height): PhpSvg
 	{
-		return new PhpSvg($width, $height);
+		$svg = new PhpSvg();
+
+		$svg->getDocument()
+			->setAttribute('viewBox', '0 0 ' . $width . ' ' . $height)
+			->setAttribute('preserveAspectRatio', 'xMidYMid meet'); // equivalent of `object-fit: contain`
+
+		return $svg;
 	}
 }

--- a/src/Charts/AbstractChart.php
+++ b/src/Charts/AbstractChart.php
@@ -48,6 +48,8 @@ abstract class AbstractChart
 
 	protected string $unitY2 = '';
 
+	protected bool $responsive = true;
+
 	/** @var array<string> */
 	protected array $colors = [
 		'#3B91C3',
@@ -139,6 +141,7 @@ abstract class AbstractChart
 	 *  fillOpacity?: float,
 	 *  unitY1?: string,
 	 *  unitY2?: string,
+	 *  responsive?: bool,
 	 * } $options
 	 */
 	public function setOptions(array $options): self
@@ -181,12 +184,21 @@ abstract class AbstractChart
 			$this->unitY2 = (string) $options['unitY2'];
 		}
 
+		if (isset($options['responsive'])) {
+			$this->responsive = (bool) $options['responsive'];
+		}
+
 		return $this;
 	}
 
 	protected function generateChart(): string
 	{
-		$image = SVG::build($this->width, $this->height);
+		if ($this->responsive) {
+			$image = SVG::buildResponsive($this->width, $this->height);
+		} else {
+			$image = SVG::build($this->width, $this->height);
+		}
+
 		$this->chart = $image->getDocument();
 
 		if ($this->isBubbleChart()) {

--- a/src/Charts/Handler/Traits.php
+++ b/src/Charts/Handler/Traits.php
@@ -54,6 +54,6 @@ trait Traits {
 		$svg = $this->generateChart();
 
 		// prettier-ignore
-		return '<img src="data:image/svg+xml;base64,' . base64_encode($svg) . '"/>';
+		return '<img src="data:image/svg+xml;base64,' . base64_encode((string) $svg) . '"/>';
 	}
 }

--- a/src/Charts/PieChart.php
+++ b/src/Charts/PieChart.php
@@ -40,6 +40,8 @@ class PieChart
 
 	private float $radius = 1;
 
+	protected bool $responsive = true;
+
 	protected SVGDocumentFragment $chart;
 
 	public function __construct(
@@ -48,10 +50,27 @@ class PieChart
 	) {
 	}
 
+	/**
+	 * @param array{ responsive?: bool } $options
+	 */
+	public function setOptions(array $options): self
+	{
+		if (isset($options['responsive'])) {
+			$this->responsive = $options['responsive'];
+		}
+
+		return $this;
+	}
+
 	/** Render the chart as a pure SVG */
 	public function generateChart(): string
 	{
-		$image = SVG::build($this->width, $this->height);
+		if ($this->responsive) {
+			$image = SVG::buildResponsive($this->width, $this->height);
+		} else {
+			$image = SVG::build($this->width, $this->height);
+		}
+
 		$this->chart = $image->getDocument();
 
 		$this->computeSum();

--- a/src/Charts/RadarChart.php
+++ b/src/Charts/RadarChart.php
@@ -56,6 +56,8 @@ class RadarChart
 
 	protected int $numLines = 5;
 
+	protected bool $responsive = true;
+
 	/** @var array<array<Dot>> */
 	protected array $dots;
 
@@ -77,7 +79,12 @@ class RadarChart
 
 	public function generateChart(): string
 	{
-		$image = SVG::build($this->width, $this->height);
+		if ($this->responsive) {
+			$image = SVG::buildResponsive($this->width, $this->height);
+		} else {
+			$image = SVG::build($this->width, $this->height);
+		}
+
 		$this->chart = $image->getDocument();
 
 		$this->computeAngle();
@@ -104,7 +111,7 @@ class RadarChart
 	}
 
 	/**
-	 * @param array{ fillOpacity?: float, stacked?: bool } $options
+	 * @param array{ fillOpacity?: float, stacked?: bool, responsive?: bool } $options
 	 */
 	public function setOptions(array $options): self
 	{
@@ -116,6 +123,10 @@ class RadarChart
 
 		if (isset($options['stacked'])) {
 			$this->stacked = (bool) $options['stacked'];
+		}
+
+		if (isset($options['responsive'])) {
+			$this->responsive = (bool) $options['responsive'];
 		}
 
 		return $this;


### PR DESCRIPTION
This PR replaces the explicit width/height with a viewBox attribute. This allows the browser to properly scale the SVG.


See:
- https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox
- https://stackoverflow.com/questions/43348351/fullscreen-svg-similar-to-object-fit-cover
- https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio