### PR TITLE
Adds missing intl extension requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "php": ">=8.1",
+        "ext-intl": "*",
         "meyfa/php-svg": "^0.15.0"
     },
     "require-dev": {


### PR DESCRIPTION
The `NumberFormatter` class used in `Pierresh\Simca\Charts\Helper::format()` requires the intl extension to be installed